### PR TITLE
Add Stemperator - AI stem separation scripts

### DIFF
--- a/config/repos.yml
+++ b/config/repos.yml
@@ -248,3 +248,6 @@ repos:
   -
     link: 'https://github.com/tomtjes/Radio-Toolkit'
     index: 'https://github.com/tomtjes/Radio-Toolkit/raw/master/index.xml'
+  -
+    link: 'https://github.com/flarkflarkflark/Stemperator'
+    index: 'https://raw.githubusercontent.com/flarkflarkflark/Stemperator/main/scripts/reaper/index.xml'


### PR DESCRIPTION
Uses Demucs/HTDemucs to separate audio into vocals, drums, bass, other, guitar, and piano stems.

  Features:
  - 13 scripts including quick actions and main dialog
  - 4-stem and 6-stem model support
  - Toolbar icons included
  - Cross-platform (Windows, Linux, macOS)

  Repository: https://github.com/flarkflarkflark/Stemperator


