### PR TITLE
Add Stemperator repository

### DIFF
--- a/config/repos.yml
+++ b/config/repos.yml
@@ -248,3 +248,6 @@ repos:
   -
     link: 'https://github.com/tomtjes/Radio-Toolkit'
     index: 'https://github.com/tomtjes/Radio-Toolkit/raw/master/index.xml'
+  -
+    link: 'https://github.com/flarkflarkflark/Stemperator'
+    index: 'https://github.com/flarkflarkflark/Stemperator/raw/main/scripts/reaper/index.xml'


### PR DESCRIPTION
## Summary

Adds Stemperator to the ReaPack repository index.

**Stemperator** is an AI-powered stem separation tool for REAPER using Demucs/HTDemucs models.

### Features
- Main dialog with full control over stem selection and model choice
- Quick action scripts (Karaoke, Vocals Only, Drums Only, Bass Only, All Stems, etc.)
- 4-stem model (Vocals, Drums, Bass, Other)
- 6-stem model (adds Guitar, Piano)
- Cross-platform support (Windows, macOS, Linux)
- GPU acceleration (NVIDIA CUDA, AMD ROCm, Apple MPS)
- Toolbar icons included

### Repository
- GitHub: https://github.com/flarkflarkflark/Stemperator
- Index: https://github.com/flarkflarkflark/Stemperator/raw/main/scripts/reaper/index.xml

### Verification
The index.xml is valid and contains:
- 14 scripts in the "AI/Stem Separation" category
- 11 toolbar icons in the "Toolbar Icons" category

All source URLs point to raw.githubusercontent.com and are accessible.