### PR TITLE
Add Stemperator repository

### DIFF
--- a/config/repos.yml
+++ b/config/repos.yml
@@ -248,3 +248,6 @@ repos:
   -
     link: 'https://github.com/tomtjes/Radio-Toolkit'
     index: 'https://github.com/tomtjes/Radio-Toolkit/raw/master/index.xml'
+  -
+    link: 'https://github.com/flarkflarkflark/Stemperator'
+    index: 'https://github.com/flarkflarkflark/Stemperator/raw/main/index.xml'


### PR DESCRIPTION
Adds Stemperator - AI Stem Separation for REAPER using Demucs/HTDemucs.

**Features:**
- 4-stem (htdemucs, htdemucs_ft) and 6-stem (htdemucs_6s) model support
- Multiple output modes: New tracks, Takes, or Blended
- GPU acceleration (NVIDIA CUDA, AMD ROCm, Apple MPS)
- Cross-platform (Windows, Linux, macOS)
- Multilingual UI (EN, NL, DE)

**Repository:** https://github.com/flarkflarkflark/Stemperator
**Index URL:** https://github.com/flarkflarkflark/Stemperator/raw/main/index.xml